### PR TITLE
Add ability to give invisible item frames to players

### DIFF
--- a/src/main/java/com/darkender/plugins/survivalinvisiframes/InvisiFramesCommand.java
+++ b/src/main/java/com/darkender/plugins/survivalinvisiframes/InvisiFramesCommand.java
@@ -1,5 +1,9 @@
 package com.darkender.plugins.survivalinvisiframes;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -8,10 +12,6 @@ import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.StringUtil;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 public class InvisiFramesCommand implements CommandExecutor, TabCompleter
 {
@@ -69,6 +69,42 @@ public class InvisiFramesCommand implements CommandExecutor, TabCompleter
             sender.sendMessage(ChatColor.GREEN + "Recipe item updated!");
             return true;
         }
+        else if (args[0].equalsIgnoreCase("give"))
+        {
+            if(!sender.hasPermission("survivalinvisiframes.give"))
+            {
+                sendNoPermissionMessage(sender);
+                return true;
+            }
+            if(args.length < 2)
+            {
+                sender.sendMessage(ChatColor.RED + "Usage: /invisiframes give <player> <amount>");
+                return true;
+            }
+            Player player = survivalInvisiframes.getServer().getPlayer(args[1]);
+            if(player == null)
+            {
+                sender.sendMessage(ChatColor.RED + "Sorry, that player is not online!");
+                return true;
+            }
+            int amount = 1;
+            if(args.length >= 3)
+            {
+                try
+                {
+                    amount = Integer.parseInt(args[2]);
+                }
+                catch(NumberFormatException e)
+                {
+                    sender.sendMessage(ChatColor.RED + "Sorry, that is not a valid number!");
+                    return true;
+                }
+            }
+            player.getInventory().addItem(SurvivalInvisiframes.generateInvisibleItemFrame(amount));
+            // player.sendMessage(ChatColor.GREEN + "Added an invisible item frame to your inventory");
+            // sender.sendMessage(ChatColor.GREEN + "Added an invisible item frame to " + player.getName() + "'s inventory");
+            return true;
+        }
         return false;
     }
     
@@ -95,6 +131,10 @@ public class InvisiFramesCommand implements CommandExecutor, TabCompleter
         if(sender.hasPermission("survivalinvisiframes.setitem"))
         {
             options.add("setitem");
+        }
+        if(sender.hasPermission("survivalinvisiframes.give"))
+        {
+            options.add("give");
         }
         List<String> completions = new ArrayList<>();
         StringUtil.copyPartialMatches(args[0], options, completions);

--- a/src/main/java/com/darkender/plugins/survivalinvisiframes/SurvivalInvisiframes.java
+++ b/src/main/java/com/darkender/plugins/survivalinvisiframes/SurvivalInvisiframes.java
@@ -31,6 +31,8 @@ public class SurvivalInvisiframes extends JavaPlugin implements Listener
     private Set<DroppedFrameLocation> droppedFrames;
     
     private boolean framesGlow;
+    private String framesName;
+    private String glowFramesName;
     private boolean firstLoad = true;
     
     // Stays null if not in 1.17
@@ -103,10 +105,14 @@ public class SurvivalInvisiframes extends JavaPlugin implements Listener
         {
             firstLoad = false;
             framesGlow = !getConfig().getBoolean("item-frames-glow");
+            framesName = getConfig().getString("item-name");
+            glowFramesName = getConfig().getString("glowing-item-name");
         }
         if(getConfig().getBoolean("item-frames-glow") != framesGlow)
         {
             framesGlow = getConfig().getBoolean("item-frames-glow");
+            framesName = getConfig().getString("item-name");
+            glowFramesName = getConfig().getString("glowing-item-name");
             forceRecheck();
         }
     
@@ -161,7 +167,7 @@ public class SurvivalInvisiframes extends JavaPlugin implements Listener
         ItemMeta meta = item.getItemMeta();
         meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         meta.addEnchant(Enchantment.DURABILITY, 1 ,true);
-        meta.setDisplayName(getInstance().getConfig().getString("item-name"));
+        meta.setDisplayName(getInstance().framesName);
         meta.getPersistentDataContainer().set(invisibleKey, PersistentDataType.BYTE, (byte) 1);
         item.setItemMeta(meta);
         return item;
@@ -173,7 +179,7 @@ public class SurvivalInvisiframes extends JavaPlugin implements Listener
         ItemMeta meta = item.getItemMeta();
         meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         meta.addEnchant(Enchantment.DURABILITY, 1 ,true);
-        meta.setDisplayName(getInstance().getConfig().getString("item-name"));
+        meta.setDisplayName(getInstance().framesName);
         meta.getPersistentDataContainer().set(invisibleKey, PersistentDataType.BYTE, (byte) 1);
         item.setItemMeta(meta);
         return item;
@@ -217,7 +223,7 @@ public class SurvivalInvisiframes extends JavaPlugin implements Listener
             {
                 ItemStack invisibleGlowingItem = generateInvisibleItemFrame();
                 ItemMeta meta = invisibleGlowingItem.getItemMeta();
-                meta.setDisplayName(getConfig().getString("glowing-item-name"));
+                meta.setDisplayName(glowFramesName);
                 invisibleGlowingItem.setItemMeta(meta);
                 invisibleGlowingItem.setType(glowFrame);
                 
@@ -316,7 +322,7 @@ public class SurvivalInvisiframes extends JavaPlugin implements Listener
                 if(glowFrame != null && item.getItemStack().getType() == glowFrame)
                 {
                     ItemMeta meta = frame.getItemMeta();
-                    meta.setDisplayName(getConfig().getString("glowing-item-name"));
+                    meta.setDisplayName(glowFramesName);
                     frame.setItemMeta(meta);
                     frame.setType(glowFrame);
                 }

--- a/src/main/java/com/darkender/plugins/survivalinvisiframes/SurvivalInvisiframes.java
+++ b/src/main/java/com/darkender/plugins/survivalinvisiframes/SurvivalInvisiframes.java
@@ -24,6 +24,8 @@ import java.util.Set;
 
 public class SurvivalInvisiframes extends JavaPlugin implements Listener
 {
+    private static SurvivalInvisiframes instance;
+    
     private NamespacedKey invisibleRecipe;
     private static NamespacedKey invisibleKey;
     private Set<DroppedFrameLocation> droppedFrames;
@@ -39,6 +41,7 @@ public class SurvivalInvisiframes extends JavaPlugin implements Listener
     @Override
     public void onEnable()
     {
+        instance = this;
         invisibleRecipe = new NamespacedKey(this, "invisible-recipe");
         invisibleKey = new NamespacedKey(this, "invisible");
         
@@ -151,14 +154,26 @@ public class SurvivalInvisiframes extends JavaPlugin implements Listener
         return (entity != null && (entity.getType() == EntityType.ITEM_FRAME ||
                 (glowFrameEntity != null && entity.getType() == glowFrameEntity)));
     }
-    
+
     public static ItemStack generateInvisibleItemFrame()
     {
         ItemStack item = new ItemStack(Material.ITEM_FRAME, 1);
         ItemMeta meta = item.getItemMeta();
         meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         meta.addEnchant(Enchantment.DURABILITY, 1 ,true);
-        meta.setDisplayName(ChatColor.WHITE + "Invisible Item Frame");
+        meta.setDisplayName(getInstance().getConfig().getString("item-name"));
+        meta.getPersistentDataContainer().set(invisibleKey, PersistentDataType.BYTE, (byte) 1);
+        item.setItemMeta(meta);
+        return item;
+    }
+    
+    public static ItemStack generateInvisibleItemFrame(int amount)
+    {
+        ItemStack item = new ItemStack(Material.ITEM_FRAME, amount);
+        ItemMeta meta = item.getItemMeta();
+        meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+        meta.addEnchant(Enchantment.DURABILITY, 1 ,true);
+        meta.setDisplayName(getInstance().getConfig().getString("item-name"));
         meta.getPersistentDataContainer().set(invisibleKey, PersistentDataType.BYTE, (byte) 1);
         item.setItemMeta(meta);
         return item;
@@ -202,7 +217,7 @@ public class SurvivalInvisiframes extends JavaPlugin implements Listener
             {
                 ItemStack invisibleGlowingItem = generateInvisibleItemFrame();
                 ItemMeta meta = invisibleGlowingItem.getItemMeta();
-                meta.setDisplayName(ChatColor.WHITE + "Glow Invisible Item Frame");
+                meta.setDisplayName(getConfig().getString("glowing-item-name"));
                 invisibleGlowingItem.setItemMeta(meta);
                 invisibleGlowingItem.setType(glowFrame);
                 
@@ -301,7 +316,7 @@ public class SurvivalInvisiframes extends JavaPlugin implements Listener
                 if(glowFrame != null && item.getItemStack().getType() == glowFrame)
                 {
                     ItemMeta meta = frame.getItemMeta();
-                    meta.setDisplayName(ChatColor.WHITE + "Glow Invisible Item Frame");
+                    meta.setDisplayName(getConfig().getString("glowing-item-name"));
                     frame.setItemMeta(meta);
                     frame.setType(glowFrame);
                 }
@@ -361,5 +376,10 @@ public class SurvivalInvisiframes extends JavaPlugin implements Listener
                 }
             }, 1L);
         }
+    }
+
+    public static SurvivalInvisiframes getInstance()
+    {
+        return instance;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -12,3 +12,8 @@ recipe:
     ==: ItemMeta
     meta-type: POTION
     potion-type: minecraft:invisibility
+
+
+# The item name
+item-name: "§fInvisible Item Frame"
+glowing-item-name: "§fGlow Invisible Item Frame"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -23,3 +23,5 @@ permissions:
     default: op
   survivalinvisiframes.setitem:
     default: op
+  survivalinvisiframes.give:
+    default: op


### PR DESCRIPTION
Add a new command `/invisiframes give` to give invisible item frames to players.
Also includes updates to the InvisiFramesCommand and SurvivalInvisiframes files to support this new functionality. 
Add a config file update to customize the display name of invisible and glowing invisible item frames